### PR TITLE
Component documentation with examples

### DIFF
--- a/docs/create_example.txt
+++ b/docs/create_example.txt
@@ -1,0 +1,26 @@
+
+To create the documentation for a component, 
+you have to create a markdown file with the same name in the same folder as the component.
+Example:
+    Footer/
+        Footer.jsx              << Component
+        Footer.md               << Documentation example
+        Footer.test.jsx         << Test of the component
+
+
+----
+
+The documentation file is markdown, and it can contains code example.
+
+Situation A, with code showcase. The code will be highlighted and display as given.
+```js static
+<Footer />
+```
+
+Situation B, with live example. The code will be renderer by Styleguidist in React, but without any way to control the rendering.
+New import (like 'import Name from 'name') doesn't work.
+```js noeditor
+<Footer />
+```
+TODO: currently 'reduxAsyncConnect' is blocking some components to render live
+

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,11 @@
+# Plone React-API
+
+This is the official frontend implementation of the Plone project.
+
+----
+
+Components are structured in three groups:
+
++ [`Theme`](#theme) is about read-only view components,
++ [`Manage`](#manage) gathers all action components,
++ and [`Mosaic`](#mosaic).

--- a/docs/manage.md
+++ b/docs/manage.md
@@ -1,0 +1,7 @@
+[comment]: # (Manage)
+[comment]: # (header-1 already done by styleguidist)
+
+The `manage` group contains action components to interact with the Plone API backend.
+
+_[Back to the top](#introduction)_
+

--- a/docs/mosaic.md
+++ b/docs/mosaic.md
@@ -1,0 +1,11 @@
+[comment]: # (Mosaic)
+[comment]: # (header-1 already done by styleguidist)
+
+Plone Mosaic is a new layout solution for Plone.
+
+Official depot of the plugin: [github.com/plone/plone.app.mosaic](https://github.com/plone/plone.app.mosaic)
+
+Read this introduction and [the package documentation](http://plone-app-mosaic.s3-website-us-east-1.amazonaws.com/latest/) for more details how to use these components.
+
+_[Back to the top](#introduction)_
+

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -1,0 +1,7 @@
+[comment]: # (Theme)
+[comment]: # (header-1 already done by styleguidist)
+
+The `theme` group contains read-only view components to structure the page display. 
+
+_[Back to the top](#introduction)_
+

--- a/package.json
+++ b/package.json
@@ -192,6 +192,7 @@
     "react-redux": "5.0.6",
     "react-router": "3.0.5",
     "react-router-redux": "4.0.8",
+    "react-styleguidist": "^6.0.25",
     "redux": "3.7.2",
     "redux-connect": "5.1.0",
     "redux-logger": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -278,6 +278,6 @@
     "webpack-hot-middleware": "2.19.1"
   },
   "engines": {
-    "node": "6.9.1"
+    "node": ">=6.9.1"
   }
 }

--- a/src/components/manage/Widgets/WysiwygWidget.jsx
+++ b/src/components/manage/Widgets/WysiwygWidget.jsx
@@ -110,7 +110,6 @@ export default class WysiwygEditor extends Component {
    * Change handler
    * @method onChange
    * @param {object} editorState Editor state.
-   * @returns {undefined}
    */
   onChange(editorState) {
     this.setState({ editorState });

--- a/src/components/theme/Footer/Footer.md
+++ b/src/components/theme/Footer/Footer.md
@@ -1,0 +1,27 @@
+Footer example, with `intl` auto-injected:
+
+```jsx static
+<Footer />
+```
+
+Output:
+
+```jsx noeditor
+const { Provider } = require('react-intl-redux');
+const configureStore = require('redux-mock-store').default;
+const store = configureStore()({
+    userSession: {
+        login: {},
+    },
+    intl: {
+        locale: 'en',
+        messages: {}
+    },
+});
+
+<div className={'rsg--pre-42'}>
+    <Provider store={store}>
+        <Footer />
+    </Provider>
+</div>
+```

--- a/src/components/theme/Header/Header.md
+++ b/src/components/theme/Header/Header.md
@@ -1,0 +1,27 @@
+Header example:
+
+```jsx static
+<Header pathname="" />
+```
+
+Output:
+
+```jsx noeditor
+const { Provider } = require('react-intl-redux');
+const configureStore = require('redux-mock-store').default;
+const store = configureStore()({
+    userSession: {
+        login: {},
+    },
+    intl: {
+        locale: 'en',
+        messages: {}
+    },
+});
+
+<div className={'rsg--pre-42'}>
+    <Provider store={store}>
+        <Header pathname="" />
+    </Provider>
+</div>
+```

--- a/src/components/theme/Login/Login.md
+++ b/src/components/theme/Login/Login.md
@@ -1,0 +1,21 @@
+Login example source:
+
+```jsx noeditor
+const { Provider } = require('react-intl-redux');
+const configureStore = require('redux-mock-store').default;
+const store = configureStore()({
+    userSession: {
+        login: {},
+    },
+    intl: {
+        locale: 'en',
+        messages: {}
+    },
+});
+
+<div className={'rsg--pre-42'}>
+    <Provider store={store}>
+        <LoginComponent error={message=""} token="" login={form => null} />
+    </Provider>
+</div>
+```

--- a/src/components/theme/Logo/Logo.md
+++ b/src/components/theme/Logo/Logo.md
@@ -10,7 +10,7 @@ Output:
 ```jsx noeditor
 var IntlProvider = require('react-intl').IntlProvider;
 
-<IntlProvider lang="en">
+<IntlProvider locale="en">
     <Logo />
 </IntlProvider>
 ```

--- a/src/components/theme/Logo/Logo.md
+++ b/src/components/theme/Logo/Logo.md
@@ -1,0 +1,16 @@
+Logo example source, with `intl` auto-injected.
+
+```jsx static
+<Logo />
+```
+
+Output:
+
+[comment]: # (import statement babel-style are not supported)
+```jsx noeditor
+var IntlProvider = require('react-intl').IntlProvider;
+
+<IntlProvider lang="en">
+    <Logo />
+</IntlProvider>
+```

--- a/src/components/theme/Logo/Logo.md
+++ b/src/components/theme/Logo/Logo.md
@@ -6,11 +6,12 @@ Logo example source, with `intl` auto-injected.
 
 Output:
 
-[comment]: # (import statement babel-style are not supported)
 ```jsx noeditor
 var IntlProvider = require('react-intl').IntlProvider;
 
-<IntlProvider locale="en">
-    <Logo />
-</IntlProvider>
+<div className={'rsg--pre-42'}>
+    <IntlProvider locale="en">
+        <Logo />
+    </IntlProvider>
+</div>
 ```

--- a/src/components/theme/Search/Search.md
+++ b/src/components/theme/Search/Search.md
@@ -1,0 +1,27 @@
+Search example:
+
+```jsx static
+<SearchComponent path="" searchableText="" items={[]} />
+```
+
+Output:
+
+```jsx noeditor
+const { Provider } = require('react-intl-redux');
+const configureStore = require('redux-mock-store').default;
+const store = configureStore()({
+    userSession: {
+        login: {},
+    },
+    intl: {
+        locale: 'en',
+        messages: {}
+    },
+});
+
+<div className={'rsg--pre-42'}>
+    <Provider store={store}>
+        <SearchComponent path="" searchableText="" items={[]} />
+    </Provider>
+</div>
+```

--- a/src/components/theme/SearchWidget/SearchWidget.md
+++ b/src/components/theme/SearchWidget/SearchWidget.md
@@ -1,0 +1,27 @@
+Search example, with `intl` auto-injected:
+
+```jsx static
+<SearchWidget pathname="" />
+```
+
+Output:
+
+```jsx noeditor
+const { Provider } = require('react-intl-redux');
+const configureStore = require('redux-mock-store').default;
+const store = configureStore()({
+    userSession: {
+        login: {},
+    },
+    intl: {
+        locale: 'en',
+        messages: {}
+    },
+});
+
+<div className={'rsg--pre-42'}>
+    <Provider store={store}>
+        <SearchWidget pathname="" />
+    </Provider>
+</div>
+```

--- a/src/components/theme/Title/Title.md
+++ b/src/components/theme/Title/Title.md
@@ -1,0 +1,13 @@
+Title example:
+
+```jsx static
+<Title title="Plone" />
+```
+
+Output:
+
+```jsx noeditor
+<div className={'rsg--pre-42'}>
+    <Title title="Plone" />
+</div>
+```

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -7,16 +7,23 @@ module.exports = {
   showUsage: true,
   sections: [
     {
+      name: 'Introduction',
+      content: 'docs/introduction.md',
+    },
+    {
       name: 'Theme',
       components: 'src/components/theme/**/*.jsx',
+      content: 'docs/theme.md',
     },
     {
       name: 'Manage',
       components: 'src/components/manage/**/*.jsx',
+      content: 'docs/manage.md',
     },
     {
       name: 'Mosaic',
       components: 'src/components/mosaic/**/*.jsx',
+      content: 'docs/mosaic.md',
     },
   ],
   webpackConfig: {


### PR DESCRIPTION
I've added one main file in markdown for each group, some examples (code showcase and live example) for some of theme's components.

Some live examples doesn't work yet, for some obscure reason related to `reduxAsyncConnect`.

The file `docs/create_example.txt` is kind of a _how to_ file about example.