### PR TITLE
fix widget proptypes for value

### DIFF
--- a/src/components/manage/Widgets/TextWidget.jsx
+++ b/src/components/manage/Widgets/TextWidget.jsx
@@ -53,7 +53,7 @@ TextWidget.propTypes = {
   description: PropTypes.string,
   required: PropTypes.bool,
   error: PropTypes.arrayOf(PropTypes.string),
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   onChange: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
Looks like that this component sometimes receive a string (for title field for example), and sometimes an object (for rich text field)