### PR TITLE
fix buildout error explained here https://community.plone.org/t/build…

### DIFF
--- a/api/buildout.cfg
+++ b/api/buildout.cfg
@@ -4,6 +4,7 @@ parts = instance
         plonesite
 extensions = mr.developer
 auto-checkout = plone.restapi
+index=https://pypi.python.org/simple/
 
 [instance]
 recipe = plone.recipe.zope2instance


### PR DESCRIPTION
…out-not-working-couldnt-find-index-page-for-couldnt-find-a-distribution-disabling-non-https-access-to-apis-on-pypi/5069/26

had to add
index=https://pypi.python.org/simple/
in buildout.cfg