### PR TITLE
Add changes to install backend section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Plone in React
 ### Install backend
 
     $ cd api
-    $ python bootstrap-buildout.py
+    $ python bootstrap-buildout.py -v 2.5.2
     $ ./bin/buildout
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Plone in React
 
 ### Install backend
 
-    $ cd api
-    $ python bootstrap-buildout.py -v 2.5.2
-    $ ./bin/buildout
+    $ virtualenv .
+    $ bin/pip install -r requirements.txt
+    $ bin/buildout
 
 ## Development
 


### PR DESCRIPTION
issue : #60 
### Actual result : 
```
Getting distribution for 'mr.developer==1.34'.
Got mr.developer 1.34.
Getting distribution for 'zc.buildout==2.5.2'.
While:
  Installing.
  Loading extensions.
  Getting distribution for 'zc.buildout==2.5.2'.

An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/media/ajayns/Projects/Code/xPR/plone-react/api/eggs/zc.buildout-2.10.0-py2.7.egg/zc/buildout/buildout.py", line 2123, in main
    getattr(buildout, command)(args)
  File "/media/ajayns/Projects/Code/xPR/plone-react/api/eggs/zc.buildout-2.10.0-py2.7.egg/zc/buildout/buildout.py", line 637, in install
    self._load_extensions()
  File "/media/ajayns/Projects/Code/xPR/plone-react/api/eggs/zc.buildout-2.10.0-py2.7.egg/zc/buildout/buildout.py", line 1163, in _load_extensions
    newest=self.newest, allow_hosts=self._allow_hosts)
  File "/media/ajayns/Projects/Code/xPR/plone-react/api/eggs/zc.buildout-2.10.0-py2.7.egg/zc/buildout/easy_install.py", line 920, in install
    return installer.install(specs, working_set)
  File "/media/ajayns/Projects/Code/xPR/plone-react/api/eggs/zc.buildout-2.10.0-py2.7.egg/zc/buildout/easy_install.py", line 721, in install
    for dist in self._get_dist(req, ws):
  File "/media/ajayns/Projects/Code/xPR/plone-react/api/eggs/zc.buildout-2.10.0-py2.7.egg/zc/buildout/easy_install.py", line 577, in _get_dist
    dist = self._env.best_match(requirement, ws)
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 1111, in best_match
    dist = working_set.find(req)
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 715, in find
    raise VersionConflict(dist, req)
VersionConflict: (zc.buildout 2.10.0 (/media/ajayns/Projects/Code/xPR/plone-react/api/eggs/zc.buildout-2.10.0-py2.7.egg), Requirement.parse('zc.buildout==2.5.2'))
```
### Expected Result : 
No conflicts

### Description of PR: 
```
    raise VersionConflict(dist, req)
VersionConflict: (zc.buildout 2.10.0 (/media/ajayns/Projects/Code/xPR/plone-react/api/eggs/zc.buildout-2.10.0-py2.7.egg), Requirement.parse('zc.buildout==2.5.2'))
```
Clearly states that there is a version conflict - the buildout file after running some set up steps requires
zc.buildout==2.5.2 but the version we have in the egg is 2.10.0 .

**Updating the documentation for installing local dev.**
