### PR TITLE
CI needs to be stable. 

### DIFF
--- a/api/buildout.cfg
+++ b/api/buildout.cfg
@@ -1,10 +1,10 @@
 [buildout]
-extends = http://dist.plone.org/release/5.1-latest/versions.cfg
+extends = http://dist.plone.org/release/5.1rc2/versions.cfg
 parts = instance
         plonesite
 extensions = mr.developer
-auto-checkout = plone.restapi
-index=https://pypi.python.org/simple/
+# auto-checkout = plone.restapi
+index = https://pypi.python.org/simple/
 
 [instance]
 recipe = plone.recipe.zope2instance
@@ -50,3 +50,6 @@ site-replace = True
 [versions]
 plone.tiles = 2.0.0b3
 plone.app.mosaic = 2.0.0rc8
+# Those pins are necessary, otherwise buildout will fail with "UnknownExtra: plone.namedfile 4.2.4 has no such extra feature 'blobs'"
+plone.namedfile = 4.2.3
+plone.app.event = 3.0.6

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,2 +1,3 @@
+# keep in sync with https://github.com/plone/buildout.coredev/blob/5.1/requirements.txt
 setuptools==33.1.1
-zc.buildout==2.9.4
+zc.buildout==2.9.5


### PR DESCRIPTION
Pin Plone version and use plone.restapi release. Pin plone.app.event and plone.namedfile to make buildout work.