### PR TITLE
configured prettier with eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
-  "extends": "airbnb",
+  "extends": ["airbnb",
+    "prettier/react",
+    "eslint-config-prettier"
+  ],
   "env": {
     "es6": true,
     "browser": true,
@@ -23,7 +26,8 @@
     ],
     "arrow-parens": "off", // Keep compatible with prettier
     "no-confusing-arrow": 0, // Keep compatible with prettier
-    "no-mixed-operators": 0, // Keep compatible with prettier
+    "no-mixed-operators": 0,
+    "no-unexpected-multiline": 0, // Keep compatible with prettier
     "indent": 0, // Keep compatible with prettier
     "prettier/prettier": [
       "error",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "build:dev:server": "better-npm-run build_dev_server",
     "run:dev:server": "better-npm-run run_dev_server",
     "clear:dist": "rm -rf dist",
-    "eslint-check": "eslint --print-config .eslintrc | eslint-config-prettier-check",
     "build":
       "npm-run-all clear:dist prod:build:client i18n:build prod:build:server",
     "build:analyse":
@@ -49,7 +48,7 @@
     "jsdoc:src": "jsdoc -c jsdoc.src.json; : 'ignore minor errors'",
     "jsdoc:api": "jsdoc -c jsdoc.api.json; : 'ignore minor errors'",
     "lint":
-      "./node_modules/eslint/bin/eslint.js -c .eslintrc src --format checkstyle --output-file eslint.xml && npm run eslint-check",
+      "./node_modules/eslint/bin/eslint.js -c .eslintrc src --format checkstyle --output-file eslint.xml && eslint-config-prettier-check",
     "lint:fix": "./node_modules/eslint/bin/eslint.js -c .eslintrc src --fix",
     "prettier":
       "./node_modules/prettier/bin-prettier.js -l 'src/**/*.js' 'src/**/*.jsx'",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jsdoc:src": "jsdoc -c jsdoc.src.json; : 'ignore minor errors'",
     "jsdoc:api": "jsdoc -c jsdoc.api.json; : 'ignore minor errors'",
     "lint":
-      "./node_modules/eslint/bin/eslint.js -c .eslintrc src --format checkstyle --output-file eslint.xml && eslint-config-prettier-check",
+      "./node_modules/eslint/bin/eslint.js -c .eslintrc src --format checkstyle --output-file eslint.xml && eslint --print-config .eslintrc | eslint-config-prettier-check",
     "lint:fix": "./node_modules/eslint/bin/eslint.js -c .eslintrc src --fix",
     "prettier":
       "./node_modules/prettier/bin-prettier.js -l 'src/**/*.js' 'src/**/*.jsx'",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build:dev:server": "better-npm-run build_dev_server",
     "run:dev:server": "better-npm-run run_dev_server",
     "clear:dist": "rm -rf dist",
+    "eslint-check": "eslint --print-config .eslintrc | eslint-config-prettier-check",
     "build":
       "npm-run-all clear:dist prod:build:client i18n:build prod:build:server",
     "build:analyse":
@@ -255,6 +256,7 @@
     "enzyme-to-json": "^3.3.1",
     "eslint": "4.18.2",
     "eslint-config-airbnb": "16.1.0",
+    "eslint-config-prettier": "2.9.0",
     "eslint-loader": "2.0.0",
     "eslint-plugin-import": "2.9.0",
     "eslint-plugin-jsx-a11y": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jsdoc:src": "jsdoc -c jsdoc.src.json; : 'ignore minor errors'",
     "jsdoc:api": "jsdoc -c jsdoc.api.json; : 'ignore minor errors'",
     "lint":
-      "./node_modules/eslint/bin/eslint.js -c .eslintrc src --format checkstyle --output-file eslint.xml",
+      "./node_modules/eslint/bin/eslint.js -c .eslintrc src --format checkstyle --output-file eslint.xml && npm run eslint-check",
     "lint:fix": "./node_modules/eslint/bin/eslint.js -c .eslintrc src --fix",
     "prettier":
       "./node_modules/prettier/bin-prettier.js -l 'src/**/*.js' 'src/**/*.jsx'",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3931,6 +3931,12 @@ eslint-config-airbnb@16.1.0:
   dependencies:
     eslint-config-airbnb-base "^12.1.0"
 
+eslint-config-prettier@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
+  dependencies:
+    get-stdin "^5.0.1"
+
 eslint-import-resolver-node@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz#4422574cde66a9a7b099938ee4d508a199e0e3cc"


### PR DESCRIPTION
Related #100
 ` npm run eslint-check ` now shows
 `No rules that are unnecessary or conflict with Prettier were found.`