### PR TITLE
Fix mr.developer, remove unnecessary pins

### DIFF
--- a/api/buildout.cfg
+++ b/api/buildout.cfg
@@ -9,7 +9,6 @@ extensions =
 auto-checkout =
     plone.restapi
 index = https://pypi.python.org/simple/
-extensions = buildout.requirements
 dump-requirements-file = docker/requirements.txt
 overwrite-requirements-file = true
 
@@ -83,25 +82,18 @@ upgrade-all-profiles = False
 site-replace = True
 
 [versions]
-setuptools =
-zc.buildout =
-zc.recipe.egg = 2.0.4
+plone.rest = 1.1.1
 plone.restapi = 2.0.1
 plone.tiles = 2.0.0b3
 plone.app.mosaic = 2.0.0rc8
-# https://community.plone.org/t/typeerror-version-object-has-no-attribute-getitem/6187/4
-plone.recipe.zope2instance = 4.4.0
 
-# Those pins are necessary, otherwise buildout will fail with "UnknownExtra: plone.namedfile 4.2.4 has no such extra feature 'blobs'"
-plone.namedfile = 4.2.3
-plone.app.event = 3.0.6
-# Travis requires specific versions
-ZEO = 5.1.0
-# Alwas use the latest versions
+# Always use the latest versions
+setuptools =
+zc.buildout =
 robotframework =
 robotframework-debuglibrary =
 robotframework-react =
 robotframework-selenium2library =
 robotframework-seleniumlibrary =
 robotframework-webpack=
-Selenium =
+selenium =

--- a/api/docker/requirements.txt
+++ b/api/docker/requirements.txt
@@ -57,7 +57,7 @@ Record==2.13.0
 RestrictedPython==3.6.0
 Unidecode==0.4.1
 ZConfig==3.1.0
-ZEO==5.1.0
+ZEO==5.1.1
 ZODB==5.3.0
 ZODB3==3.11.0
 ZServer==3.0
@@ -92,6 +92,7 @@ lxml==4.1.1
 mailinglogger==3.8.0
 mechanize==0.2.5
 mockup==2.7.2
+mr.developer==1.38
 olefile==0.44
 pathlib==1.0.1
 persistent==4.2.4.2
@@ -112,7 +113,7 @@ plone.app.customerize==1.3.7
 plone.app.dexterity==2.4.9
 plone.app.discussion==3.0.5
 plone.app.drafts==1.1.2
-plone.app.event==3.0.6
+plone.app.event==3.1
 plone.app.folder==1.2.5
 plone.app.i18n==3.0.4
 plone.app.imaging==2.0.7
@@ -165,13 +166,13 @@ plone.jsonserializer==0.9.5
 plone.keyring==3.0.2
 plone.locking==2.2.2
 plone.memoize==1.2.2
-plone.namedfile==4.2.3
+plone.namedfile==4.2.4
 plone.outputfilters==3.0.4
 plone.portlet.collection==3.3.0
 plone.portlet.static==3.1.2
 plone.portlets==2.3
 plone.protect==3.1.3
-plone.recipe.zope2instance==4.4.0
+plone.recipe.zope2instance==4.3
 plone.registry==1.1.2
 plone.resource==2.0.1
 plone.resourceeditor==2.1.1


### PR DESCRIPTION
It seems that we don't have to override so many pins from Plone.

This also fixes the double buildout `extensions` so that mr.developer works.